### PR TITLE
feat: add indexeddb persistence for tab state

### DIFF
--- a/features/json-workspace.tsx
+++ b/features/json-workspace.tsx
@@ -43,8 +43,8 @@ export function JsonWorkspace() {
   const saveJson = useJsonStore((state) => state.saveJson);
   const clearJson = useJsonStore((state) => state.clearJson);
   const setJsonContent = useJsonStore((state) => state.setJsonContent);
-  const loadFromSessionStorage = useJsonStore(
-    (state) => state.loadFromSessionStorage,
+  const loadFromIndexedDB = useJsonStore(
+    (state) => state.loadFromIndexedDB,
   );
 
   const isValid = validation.isValid;
@@ -52,8 +52,8 @@ export function JsonWorkspace() {
   const parsedJson = validation.parsedJson;
 
   useEffect(() => {
-    loadFromSessionStorage();
-  }, [loadFromSessionStorage]);
+    void loadFromIndexedDB();
+  }, [loadFromIndexedDB]);
 
   useEffect(() => {
     if (editorRef.current && editorRef.current.getValue() !== jsonContent) {

--- a/lib/json-storage-service.ts
+++ b/lib/json-storage-service.ts
@@ -1,0 +1,257 @@
+import Dexie, { type Table } from "dexie";
+
+const DB_NAME = "JSON_VISUALISER_TAB_STATE";
+const TAB_ID_STORAGE_KEY = "json-visualiser-tab-id";
+const CHANNEL_NAME = "json-visualiser-tab-sync";
+const CLOSE_MARKER_PREFIX = "json-visualiser-tab-close:";
+const CLOSED_TAB_GRACE_PERIOD_MS = 15_000;
+
+type TTabState = {
+  tabId: string;
+  content: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+type TTabChannelMessage =
+  | {
+      type: "who-has-tab-id";
+      tabId: string;
+      requestId: string;
+      from: string;
+    }
+  | {
+      type: "tab-id-in-use";
+      tabId: string;
+      requestId: string;
+      from: string;
+    };
+
+class JsonTabStateDB extends Dexie {
+  tabStates!: Table<TTabState>;
+
+  constructor() {
+    super(DB_NAME);
+    this.version(1).stores({
+      tabStates: "tabId, updatedAt, createdAt",
+    });
+  }
+}
+
+const db = new JsonTabStateDB();
+
+class JsonStorageService {
+  private readonly instanceId =
+    typeof crypto !== "undefined" ? crypto.randomUUID() : `${Date.now()}`;
+  private channel: BroadcastChannel | null = null;
+  private resolvedTabId: string | null = null;
+  private tabIdPromise: Promise<string> | null = null;
+  private hasCleanupHandler = false;
+
+  private getChannel() {
+    if (typeof window === "undefined" || typeof BroadcastChannel === "undefined") {
+      return null;
+    }
+    if (!this.channel) {
+      this.channel = new BroadcastChannel(CHANNEL_NAME);
+      this.channel.addEventListener("message", this.handleChannelMessage);
+    }
+    return this.channel;
+  }
+
+  private handleChannelMessage = (event: MessageEvent<TTabChannelMessage>) => {
+    const data = event.data;
+    if (!data || data.type !== "who-has-tab-id") {
+      return;
+    }
+    if (!this.resolvedTabId || data.from === this.instanceId) {
+      return;
+    }
+    if (data.tabId !== this.resolvedTabId) {
+      return;
+    }
+
+    this.channel?.postMessage({
+      type: "tab-id-in-use",
+      tabId: data.tabId,
+      requestId: data.requestId,
+      from: this.instanceId,
+    } satisfies TTabChannelMessage);
+  };
+
+  private async hasTabConflict(tabId: string): Promise<boolean> {
+    const channel = this.getChannel();
+    if (!channel) {
+      return false;
+    }
+
+    return new Promise<boolean>((resolve) => {
+      const requestId = crypto.randomUUID();
+      let hasConflict = false;
+
+      const onMessage = (event: MessageEvent<TTabChannelMessage>) => {
+        const data = event.data;
+        if (!data || data.type !== "tab-id-in-use") {
+          return;
+        }
+        if (data.from === this.instanceId) {
+          return;
+        }
+        if (data.requestId === requestId && data.tabId === tabId) {
+          hasConflict = true;
+        }
+      };
+
+      channel.addEventListener("message", onMessage);
+      channel.postMessage({
+        type: "who-has-tab-id",
+        tabId,
+        requestId,
+        from: this.instanceId,
+      } satisfies TTabChannelMessage);
+
+      window.setTimeout(() => {
+        channel.removeEventListener("message", onMessage);
+        resolve(hasConflict);
+      }, 120);
+    });
+  }
+
+  private async resolveUniqueTabId(): Promise<string> {
+    if (typeof window === "undefined") {
+      return "server";
+    }
+
+    let candidate =
+      sessionStorage.getItem(TAB_ID_STORAGE_KEY) ?? crypto.randomUUID();
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const conflict = await this.hasTabConflict(candidate);
+      if (!conflict) {
+        break;
+      }
+      candidate = crypto.randomUUID();
+    }
+
+    sessionStorage.setItem(TAB_ID_STORAGE_KEY, candidate);
+    this.resolvedTabId = candidate;
+    return candidate;
+  }
+
+  async getOrCreateTabId(): Promise<string> {
+    if (this.resolvedTabId) {
+      return this.resolvedTabId;
+    }
+
+    if (!this.tabIdPromise) {
+      this.tabIdPromise = this.resolveUniqueTabId();
+    }
+
+    const tabId = await this.tabIdPromise;
+    this.clearCloseMarker(tabId);
+    return tabId;
+  }
+
+  async getTabState(tabId: string): Promise<TTabState | null> {
+    const state = await db.tabStates.get(tabId);
+    return state ?? null;
+  }
+
+  async saveTabState(tabId: string, content: string): Promise<void> {
+    const now = Date.now();
+    const existing = await db.tabStates.get(tabId);
+    await db.tabStates.put({
+      tabId,
+      content,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    });
+  }
+
+  async deleteTabState(tabId: string): Promise<void> {
+    await db.tabStates.delete(tabId);
+  }
+
+  async cleanupStaleTabs(cutoffMs: number): Promise<number> {
+    const stale = await db.tabStates.where("updatedAt").below(cutoffMs).toArray();
+    if (stale.length === 0) {
+      return 0;
+    }
+
+    await db.tabStates.bulkDelete(stale.map((item) => item.tabId));
+    return stale.length;
+  }
+
+  private getCloseMarkerKey(tabId: string) {
+    return `${CLOSE_MARKER_PREFIX}${tabId}`;
+  }
+
+  private markTabClosing(tabId: string) {
+    if (typeof window === "undefined") {
+      return;
+    }
+    localStorage.setItem(this.getCloseMarkerKey(tabId), `${Date.now()}`);
+  }
+
+  private clearCloseMarker(tabId: string) {
+    if (typeof window === "undefined") {
+      return;
+    }
+    localStorage.removeItem(this.getCloseMarkerKey(tabId));
+  }
+
+  async cleanupClosedTabs(
+    gracePeriodMs: number = CLOSED_TAB_GRACE_PERIOD_MS
+  ): Promise<number> {
+    if (typeof window === "undefined") {
+      return 0;
+    }
+
+    const now = Date.now();
+    const markers: string[] = [];
+    for (let i = 0; i < localStorage.length; i += 1) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith(CLOSE_MARKER_PREFIX)) {
+        markers.push(key);
+      }
+    }
+
+    let deletedCount = 0;
+    for (const key of markers) {
+      const tabId = key.slice(CLOSE_MARKER_PREFIX.length);
+      const markedAt = Number(localStorage.getItem(key) ?? "0");
+      if (!Number.isFinite(markedAt) || now - markedAt < gracePeriodMs) {
+        continue;
+      }
+
+      const hasConflict = await this.hasTabConflict(tabId);
+      if (!hasConflict) {
+        await this.deleteTabState(tabId);
+        deletedCount += 1;
+      }
+      localStorage.removeItem(key);
+    }
+
+    return deletedCount;
+  }
+
+  registerLifecycleCleanup() {
+    if (typeof window === "undefined" || this.hasCleanupHandler) {
+      return;
+    }
+    this.hasCleanupHandler = true;
+
+    const markCurrentTabClosing = () => {
+      const tabId = this.resolvedTabId ?? sessionStorage.getItem(TAB_ID_STORAGE_KEY);
+      if (!tabId) {
+        return;
+      }
+      this.markTabClosing(tabId);
+    };
+
+    window.addEventListener("pagehide", markCurrentTabClosing);
+    window.addEventListener("beforeunload", markCurrentTabClosing);
+  }
+}
+
+export const indexedDBService = new JsonStorageService();

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "clsx": "^2.1.1",
     "d3-force": "^3.0.0",
     "deepmerge": "^4.3.1",
+    "dexie": "^4.3.0",
     "json-to-ts": "^2.1.0",
     "lucide-react": "^0.526.0",
     "monaco-editor": "^0.52.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
+      dexie:
+        specifier: ^4.3.0
+        version: 4.3.0
       json-to-ts:
         specifier: ^2.1.0
         version: 2.1.0
@@ -370,92 +373,78 @@ packages:
     resolution: {integrity: sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.0':
     resolution: {integrity: sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.0':
     resolution: {integrity: sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.0':
     resolution: {integrity: sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.0':
     resolution: {integrity: sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.0':
     resolution: {integrity: sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.0':
     resolution: {integrity: sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.3':
     resolution: {integrity: sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.3':
     resolution: {integrity: sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.3':
     resolution: {integrity: sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.3':
     resolution: {integrity: sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.3':
     resolution: {integrity: sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.3':
     resolution: {integrity: sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.3':
     resolution: {integrity: sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.3':
     resolution: {integrity: sha512-+CyRcpagHMGteySaWos8IbnXcHgfDn7pO2fiC2slJxvNq9gDipYBN42/RagzctVRKgxATmfqOSulgZv5e1RdMg==}
@@ -530,28 +519,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.4.8':
     resolution: {integrity: sha512-DX/L8VHzrr1CfwaVjBQr3GWCqNNFgyWJbeQ10Lx/phzbQo3JNAxUok1DZ8JHRGcL6PgMRgj6HylnLNndxn4Z6A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.4.8':
     resolution: {integrity: sha512-9fLAAXKAL3xEIFdKdzG5rUSvSiZTLLTCc6JKq1z04DR4zY7DbAPcRvNm3K1inVhTiQCs19ZRAgUerHiVKMZZIA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.4.8':
     resolution: {integrity: sha512-s45V7nfb5g7dbS7JK6XZDcapicVrMMvX2uYgOHP16QuKH/JA285oy6HcxlKqwUNaFY/UC6EvQ8QZUOo19cBKSA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.4.8':
     resolution: {integrity: sha512-KjgeQyOAq7t/HzAJcWPGA8X+4WY03uSCZ2Ekk98S9OgCFsb6lfBE3dbUzUuEQAN2THbwYgFfxX2yFTCMm8Kehw==}
@@ -1435,28 +1420,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.11':
     resolution: {integrity: sha512-m/NVRFNGlEHJrNVk3O6I9ggVuNjXHIPoD6bqay/pubtYC9QIdAMpS+cswZQPBLvVvEF6GtSNONbDkZrjWZXYNQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.11':
     resolution: {integrity: sha512-YW6sblI7xukSD2TdbbaeQVDysIm/UPJtObHJHKxDEcW2exAtY47j52f8jZXkqE1krdnkhCMGqP3dbniu1Te2Fg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.11':
     resolution: {integrity: sha512-e3C/RRhGunWYNC3aSF7exsQkdXzQ/M+aYuZHKnw4U7KQwTJotnWsGOIVih0s2qQzmEzOFIJ3+xt7iq67K/p56Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.11':
     resolution: {integrity: sha512-Xo1+/GU0JEN/C/dvcammKHzeM6NqKovG+6921MR6oadee5XPBaKOumrJCXvopJ/Qb5TH7LX/UAywbqrP4lax0g==}
@@ -1782,6 +1763,9 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dexie@4.3.0:
+    resolution: {integrity: sha512-5EeoQpJvMKHe6zWt/FSIIuRa3CWlZeIl6zKXt+Lz7BU6RoRRLgX9dZEynRfXrkLcldKYCBiz7xekTEylnie1Ug==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2175,28 +2159,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -4515,6 +4495,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  dexie@4.3.0: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/stores/json-document-store.ts
+++ b/stores/json-document-store.ts
@@ -1,8 +1,10 @@
 "use client";
 
 import { create } from "zustand";
+import { indexedDBService } from "@/lib/json-storage-service";
 
-const STORAGE_KEY = "json-visualiser-content";
+const LEGACY_SESSION_STORAGE_KEY = "json-visualiser-content";
+const STALE_TABS_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 export type TValidationResult = {
   isValid: boolean;
@@ -21,7 +23,7 @@ export type TJsonStore = {
   setJsonContent: (content: string) => void;
   saveJson: (content: string) => void;
   clearJson: () => void;
-  loadFromSessionStorage: () => void;
+  loadFromIndexedDB: () => Promise<void>;
   getValidation: () => TValidationResult;
   getStats: () => TJsonStats;
   hasContent: () => boolean;
@@ -43,26 +45,47 @@ export const useJsonStore = create<TJsonStore>((set, get) => ({
     set({ jsonContent: content });
     validationCache.clear();
     statsCache.clear();
-    if (typeof window !== "undefined") {
-      sessionStorage.setItem(STORAGE_KEY, content);
-    }
+    if (typeof window === "undefined") return;
+
+    void (async () => {
+      const tabId = await indexedDBService.getOrCreateTabId();
+      await indexedDBService.saveTabState(tabId, content);
+    })();
   },
 
   clearJson: () => {
     set({ jsonContent: "" });
     validationCache.clear();
     statsCache.clear();
-    if (typeof window !== "undefined") {
-      sessionStorage.removeItem(STORAGE_KEY);
-    }
+    if (typeof window === "undefined") return;
+
+    void (async () => {
+      const tabId = await indexedDBService.getOrCreateTabId();
+      await indexedDBService.deleteTabState(tabId);
+    })();
   },
 
-  loadFromSessionStorage: () => {
-    if (typeof window !== "undefined") {
-      const saved = sessionStorage.getItem(STORAGE_KEY);
-      if (saved !== null) {
-        set({ jsonContent: saved });
-      }
+  loadFromIndexedDB: async () => {
+    if (typeof window === "undefined") return;
+
+    indexedDBService.registerLifecycleCleanup();
+    const tabId = await indexedDBService.getOrCreateTabId();
+    const cutoffMs = Date.now() - STALE_TABS_TTL_MS;
+    void indexedDBService.cleanupStaleTabs(cutoffMs);
+    void indexedDBService.cleanupClosedTabs();
+
+    const persisted = await indexedDBService.getTabState(tabId);
+    if (persisted) {
+      set({ jsonContent: persisted.content });
+      return;
+    }
+
+    // One-time migration from legacy sessionStorage persistence.
+    const legacyContent = sessionStorage.getItem(LEGACY_SESSION_STORAGE_KEY);
+    if (legacyContent !== null) {
+      set({ jsonContent: legacyContent });
+      await indexedDBService.saveTabState(tabId, legacyContent);
+      sessionStorage.removeItem(LEGACY_SESSION_STORAGE_KEY);
     }
   },
 

--- a/stores/json-document-store.ts
+++ b/stores/json-document-store.ts
@@ -60,8 +60,12 @@ export const useJsonStore = create<TJsonStore>((set, get) => ({
     if (typeof window === "undefined") return;
 
     void (async () => {
-      const tabId = await indexedDBService.getOrCreateTabId();
-      await indexedDBService.deleteTabState(tabId);
+      try {
+        const tabId = await indexedDBService.getOrCreateTabId();
+        await indexedDBService.deleteTabState(tabId);
+      } catch (error) {
+        console.error("Failed to clear persisted JSON state", error);
+      }
     })();
   },
 


### PR DESCRIPTION
fixes https://github.com/thatbeautifuldream/jsonvisualiser/issues/3

- Introduces `JsonStorageService` backed by IndexedDB (via Dexie) to persist JSON content per browser tab across sessions
- Replaces the previous `sessionStorage` approach with a tab-aware IndexedDB store that uses `BroadcastChannel` to coordinate tab IDs across windows
- Migrates `useJsonStore` to load and save content via `indexedDBService`, with a grace-period cleanup for stale tabs and a legacy session storage migration path

## Test plan

- [x] Open the app in a new tab, paste JSON, reload — content should persist
- [x] Open the same URL in multiple tabs and verify each tab maintains its own isolated state
- [x] Close a tab, reopen, and confirm the content is restored within the grace period
- [x] Verify stale tab records older than 7 days are cleaned up on load
- [x] Confirm no regressions in JSON validation, stats, or workspace functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-tab synchronization for tab states, enabling real-time consistency across open windows
  * Persistent browser-backed storage for tab content with one-time migration from legacy session storage

* **Chores**
  * Automatic cleanup of stale and closed tab states to reduce leftover data
  * Lifecycle handling to improve stability when tabs are closed or refreshed
<!-- end of auto-generated comment: release notes by coderabbit.ai -->