### PR TITLE
feat: add JSON unescape action

### DIFF
--- a/features/editor-toolbar.tsx
+++ b/features/editor-toolbar.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 type TEditorToolbarProps = {
   onFormat: () => void;
   onMinify: () => void;
+  onUnescapeJson: () => void;
   onCopy: () => void;
   onClear: () => void;
   onGenerateTypes?: () => void;
@@ -38,6 +39,7 @@ const ToolbarButton = ({
 export function EditorToolbar({
   onFormat,
   onMinify,
+  onUnescapeJson,
   onCopy,
   onClear,
   onGenerateTypes,
@@ -54,6 +56,9 @@ export function EditorToolbar({
       </ToolbarButton>
       <ToolbarButton onClick={onMinify} disabled={!isValid || !hasContent}>
         Minify
+      </ToolbarButton>
+      <ToolbarButton onClick={onUnescapeJson} disabled={!hasContent}>
+        JSON Unescape
       </ToolbarButton>
       <ToolbarButton onClick={onCopy} disabled={!hasContent}>
         Copy

--- a/features/editor-toolbar.tsx
+++ b/features/editor-toolbar.tsx
@@ -58,7 +58,7 @@ export function EditorToolbar({
         Minify
       </ToolbarButton>
       <ToolbarButton onClick={onUnescapeJson} disabled={!hasContent}>
-        JSON Unescape
+        Unescape
       </ToolbarButton>
       <ToolbarButton onClick={onCopy} disabled={!hasContent}>
         Copy

--- a/features/json-workspace.tsx
+++ b/features/json-workspace.tsx
@@ -22,6 +22,7 @@ import { JsonGraphViewer } from "@/components/json-graph-viewer";
 import { TypeGeneratorDialog } from "./type-generator-dialog";
 import { ThemeSwitcher } from "@/components/theme-switcher";
 import { GitHubLink } from "./github-link";
+import { unescapeJsonText } from "@/lib/unescape-json";
 
 type EditorTheme = "light" | "hc-black";
 
@@ -144,6 +145,25 @@ export function JsonWorkspace({
       console.error("Minification error:", err);
     }
   }, [isValid, setJsonContent, saveJson]);
+
+  const unescapeJson = useCallback(() => {
+    if (!editorRef.current) return;
+
+    const currentValue = editorRef.current.getValue();
+    const { value, replacementCount } = unescapeJsonText(currentValue);
+
+    if (replacementCount === 0) {
+      toast.error("No supported escape sequences found");
+      return;
+    }
+
+    editorRef.current.setValue(value);
+    startTransition(() => {
+      setJsonContent(value);
+      saveJson(value);
+    });
+    toast.success("JSON escape sequences removed");
+  }, [saveJson, setJsonContent]);
 
   const copyToClipboard = useCallback(async () => {
     if (!editorRef.current) return;
@@ -303,6 +323,7 @@ export function JsonWorkspace({
         <EditorToolbar
           onFormat={formatJson}
           onMinify={minifyJson}
+          onUnescapeJson={unescapeJson}
           onCopy={copyToClipboard}
           onClear={clearEditor}
           onGenerateTypes={generateTypes}
@@ -322,6 +343,7 @@ export function JsonWorkspace({
     hasFileContent,
     isValid,
     minifyJson,
+    unescapeJson,
     clearEditor,
   ]);
 

--- a/lib/unescape-json.ts
+++ b/lib/unescape-json.ts
@@ -1,0 +1,25 @@
+const JSON_UNESCAPE_SEQUENCES: Record<string, string> = {
+  b: "\b",
+  f: "\f",
+  n: "\n",
+  r: "\r",
+  t: "\t",
+  '"': '"',
+  "\\": "\\",
+};
+
+const JSON_UNESCAPE_PATTERN = /\\([bfnrt"\\])/g;
+
+export function unescapeJsonText(input: string) {
+  let replacementCount = 0;
+
+  const value = input.replace(JSON_UNESCAPE_PATTERN, (_, sequence: string) => {
+    replacementCount += 1;
+    return JSON_UNESCAPE_SEQUENCES[sequence] ?? _;
+  });
+
+  return {
+    value,
+    replacementCount,
+  };
+}


### PR DESCRIPTION
## Summary
- add a JSON Unescape button to the top toolbar
- unescape supported JSON escape sequences in the current editor content
- save the updated content back into the editor/workspace
- show toast feedback after unescaping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Unescape" button to the editor toolbar that removes JSON escape sequences (such as `\n`, `\t`, `\"`, `\\`, `\b`, `\f`, `\r`) from your editor content. The button includes feedback notifications for success or when no escape sequences are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->